### PR TITLE
update: Finding fields in parent classes and interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <name>smart-doc-qdox</name>
     <groupId>com.github.shalousun</groupId>
     <artifactId>qdox</artifactId>
-    <version>2.0.3.2</version>
+    <version>2.0.3.3</version>
 
     <url>https://github.com/paul-hammant/qdox</url>
     <description>

--- a/src/main/java/com/thoughtworks/qdox/model/JavaClass.java
+++ b/src/main/java/com/thoughtworks/qdox/model/JavaClass.java
@@ -229,7 +229,13 @@ public interface JavaClass extends JavaModel, JavaType, JavaAnnotatedElement, Ja
      * @return the field
      */
     JavaField getFieldByName( String name );
-    
+
+
+    List<JavaField> getFields( boolean publicOnly, boolean supperClass );
+
+    JavaField getFieldByName( String name, boolean publicOnly, boolean supperClass );
+
+
     /**
      * Based on {@link java.lang.Class#getEnumConstants()}.
      *  

--- a/src/main/java/com/thoughtworks/qdox/model/expression/FieldRef.java
+++ b/src/main/java/com/thoughtworks/qdox/model/expression/FieldRef.java
@@ -166,7 +166,7 @@ public class FieldRef
 
         for ( int i = start; i < end; ++i )
         {
-            field = javaClass.getFieldByName( getNamePart( i ) );
+            field = javaClass.getFieldByName( getNamePart( i ), true, true );
 
             if ( field != null )
             {
@@ -213,20 +213,6 @@ public class FieldRef
                 ClassLibrary classLibrary = getClassLibrary();
                 if ( classLibrary != null && declaringClass != null)
                 {
-                    //  Constants are defined in the parent class or interface
-                    List<JavaClass> interfacesOrSupperClass = declaringClass.getInterfaces();
-                    JavaType superClass = declaringClass.getSuperClass();
-                    if (superClass instanceof JavaClass){
-                        interfacesOrSupperClass.add((JavaClass) superClass);
-                    }
-                    for ( JavaClass javaClass : interfacesOrSupperClass) {
-                        JavaField tmpField = javaClass.getFieldByName( getName() );
-                        if ( tmpField != null && tmpField.isStatic()) {
-                            field = tmpField;
-                           return field;
-                        }
-                    }
-
                     // Constants are "import static"
                     List<String> imports = declaringClass.getSource().getImports();
                     for ( String i : imports )
@@ -239,7 +225,7 @@ public class FieldRef
                                 String className =  i.substring( 7, i.lastIndexOf( '.' ) ).trim();
                                 JavaClass javaClass = classLibrary.getJavaClass( className );
                                 String fieldName = "*".equals(member) ? getName() : member;
-                                JavaField tmpField = javaClass.getFieldByName( fieldName );
+                                JavaField tmpField = javaClass.getFieldByName( fieldName,true, true);
                                 if ( tmpField != null && ( javaClass.isInterface() || tmpField.isStatic() ) )
                                 {
                                     field = tmpField;

--- a/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaClass.java
+++ b/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaClass.java
@@ -19,13 +19,7 @@ package com.thoughtworks.qdox.model.impl;
  * under the License.
  */
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import com.thoughtworks.qdox.library.ClassLibrary;
 import com.thoughtworks.qdox.model.BeanProperty;
@@ -568,6 +562,67 @@ public class DefaultJavaClass
         return null;
     }
 
+
+    private List<JavaField> getDeclaredFields(boolean publicOnly) {
+        List<JavaField> javaFields = new ArrayList<>(fields.size());
+        for (JavaField field : fields) {
+            if (field != null && (!publicOnly || field.isPublic())) {
+                javaFields.add(field);
+            }
+        }
+        return javaFields;
+    }
+
+    @Override
+    public List<JavaField> getFields(boolean publicOnly, boolean supperClass) {
+        List<JavaField> javaFields = getDeclaredFields(publicOnly);
+
+        if (!supperClass) {
+            return javaFields;
+        }
+        // find in interfaces
+        List<JavaClass> interfaces = getInterfaces();
+        for (JavaClass javaClass : interfaces) {
+            javaFields.addAll(javaClass.getFields(publicOnly, true));
+        }
+        // find in superJavaClass
+        JavaClass superJavaClass = getSuperJavaClass();
+        if (superJavaClass != null) {
+            javaFields.addAll(superJavaClass.getFields(publicOnly, true));
+        }
+        return javaFields;
+    }
+
+    @Override
+    public JavaField getFieldByName(String name, boolean publicOnly, boolean supperClass) {
+        if (name == null){
+            return null;
+        }
+
+        List<JavaField> fieldList = getDeclaredFields(publicOnly);
+        for (JavaField javaField : fieldList) {
+            if ( name.equals( javaField.getName() )){
+                return javaField;
+            }
+        }
+        if (!supperClass){
+            return null;
+        }
+        // find in interfaces
+        List<JavaClass> interfaces = getInterfaces();
+        for (JavaClass javaClass : interfaces) {
+            JavaField javaField = javaClass.getFieldByName(name, publicOnly, true);
+            if ( javaField != null) {
+                return javaField;
+            }
+        }
+        // find in superJavaClass
+        JavaClass superJavaClass = getSuperJavaClass();
+        if ( superJavaClass != null) {
+            return superJavaClass.getFieldByName(name, publicOnly,true);
+        }
+        return null;
+    }
     /** {@inheritDoc} */
     public List<JavaField> getEnumConstants()
     {

--- a/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaField.java
+++ b/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaField.java
@@ -194,4 +194,19 @@ public class DefaultJavaField
         }
         return hashCode;
     }
+
+    @Override
+    public boolean isStatic() {
+        return (getDeclaringClass() != null && getDeclaringClass().isInterface()) || super.isStatic();
+    }
+
+    @Override
+    public boolean isFinal() {
+        return (getDeclaringClass() != null && getDeclaringClass().isInterface()) || super.isFinal();
+    }
+
+    @Override
+    public boolean isPublic() {
+        return (getDeclaringClass() != null && getDeclaringClass().isInterface()) || super.isPublic();
+    }
 }

--- a/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaType.java
+++ b/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaType.java
@@ -747,6 +747,16 @@ public class DefaultJavaType implements JavaClass, JavaType, Serializable {
         return resolveRealClass().getFields();
     }
 
+    @Override
+    public List<JavaField> getFields(boolean publicOnly, boolean supperClass) {
+        return resolveRealClass().getFields(publicOnly, supperClass);
+    }
+
+    @Override
+    public JavaField getFieldByName(String name, boolean publicOnly, boolean supperClass) {
+        return resolveRealClass().getFieldByName(name, publicOnly, supperClass);
+    }
+
     /** {@inheritDoc} */
     public JavaField getFieldByName( String name )
     {


### PR DESCRIPTION
You can use fields from parent classes and interfaces, but you cannot concatenate strings because qdox only supports concatenated strings within annotations.